### PR TITLE
Cleanup repoDir before running git clone

### DIFF
--- a/cmds/aggregator.go
+++ b/cmds/aggregator.go
@@ -249,7 +249,14 @@ func hasKey(m map[string]interface{}, key string) bool {
 func processAssets(a api.AssetListing, rootDir string, sh *shell.Session, tmpDir string) error {
 	tmpDir = filepath.Join(tmpDir, "assets")
 	repoDir := filepath.Join(tmpDir, "repo")
-	err := os.MkdirAll(repoDir, 0755)
+	// repoDir may already exist and not be empty. In this case, "git clone" will fail.
+	// remove repoDir first.
+	err := os.RemoveAll(repoDir)
+	if err != nil {
+		return err
+	}
+
+	err = os.MkdirAll(repoDir, 0755)
 	if err != nil {
 		return err
 	}
@@ -285,7 +292,13 @@ func processAssets(a api.AssetListing, rootDir string, sh *shell.Session, tmpDir
 func processProduct(p api.Product, rootDir string, sh *shell.Session, tmpDir string) error {
 	tmpDir = filepath.Join(tmpDir, p.Key)
 	repoDir := filepath.Join(tmpDir, "repo")
-	err := os.MkdirAll(repoDir, 0755)
+	// repoDir may already exist and not be empty. In this case, "git clone" will fail.
+	// remove repoDir first.
+	err := os.RemoveAll(repoDir)
+	if err != nil {
+		return err
+	}
+	err = os.MkdirAll(repoDir, 0755)
 	if err != nil {
 		return err
 	}
@@ -524,7 +537,13 @@ func processSubproject(p api.Product, v api.ProductVersion, rootDir, vDir string
 	for spKey, info := range p.SubProjects {
 		tmpDir := filepath.Join(rootTempDir, spKey)
 		repoDir := filepath.Join(tmpDir, "repo")
-		err := os.MkdirAll(repoDir, 0755)
+		// repoDir may already exist and not be empty. In this case, "git clone" will fail.
+		// remove repoDir first.
+		err := os.RemoveAll(repoDir)
+		if err != nil {
+			return err
+		}
+		err = os.MkdirAll(repoDir, 0755)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Cleanup `repoDir` before running `git clone` as it will fail if `repoDir` is not empty.

If a project has version mapping for sub projects where different version of the project uses same sub project (may be different version but same repo) then the `repoDir` for the sub project will be populated while processing first version of the project. So, while processing another version of the project, the `repoDir` will not be empty for the sub project. So, `git clone` will fail. In this case, we need to cleanup the `repoDir` before running `git clone`.

Ref: https://github.com/appscode/static-assets/blob/73eaac03b437b3ed6b91746ee12d5fe0366ba9f6/data/products/stash.json#L337