### PR TITLE
Resolve templated part of main project's front matter

### DIFF
--- a/cmds/aggregator.go
+++ b/cmds/aggregator.go
@@ -395,6 +395,15 @@ func processProduct(p api.Product, rootDir string, sh *shell.Session, tmpDir str
 			var out string
 			frontmatter := page.FrontMatter()
 
+			// resolve any templated part in front matter
+			t := template.Must(template.New("xF").Parse(string(frontmatter)))
+			var resolvedFrontMatter bytes.Buffer
+			err = t.Execute(&resolvedFrontMatter, v)
+			if err != nil {
+				return err
+			}
+			frontmatter = resolvedFrontMatter.Bytes()
+
 			if len(frontmatter) != 0 {
 				out = "---\n"
 


### PR DESCRIPTION
**Why?**

This allows us to template version part of a project in front-matter. Which will give us the following benefits:
- No more global search and replace for version filed before each release.
- Easy to test doc rendering of dev branch. Otherwise, we have to copy & replace the contents of dev branch to latest release branch then render it.