### PR TITLE
Remove docs dir when hostDocs is false

### DIFF
--- a/cmds/aggregator.go
+++ b/cmds/aggregator.go
@@ -398,11 +398,16 @@ func processProduct(sh *shell.Session, p api.Product, allVersions bool, multiPro
 	sh.SetDir(wdCur)
 
 	for _, v := range p.Versions {
+		vDir := filepath.Join(scriptRoot, "content", docsDir, v.Version)
+
 		if !v.HostDocs {
+			if dirExists(vDir) {
+				if err := os.RemoveAll(vDir); err != nil {
+					return err
+				}
+			}
 			continue
 		}
-
-		vDir := filepath.Join(scriptRoot, "content", docsDir, v.Version)
 
 		if !allVersions && v.Version != p.LatestVersion && dirExists(vDir) {
 			continue


### PR DESCRIPTION
If a product version has `hostDocs: false`, remove the matching docs folder if it exists on disk.